### PR TITLE
Fix webpack/js error with loading of app.js

### DIFF
--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -48,4 +48,4 @@
 
 {{ partial "svg" . }}
 
-<script src="/app.js"></script>
+


### PR DESCRIPTION
**- Summary**

It looks like webpack compiles all the js (including app.js)
into a generated file called main.js. So don't try to load app.js,
everything is included in main.js. This seems to be a bug that
came with the starter template project.

**- Test plan**

Both locally and on the netlify hosted version of the site
(https://hugo-enlist-io.netlify.com/), open developer tools and note
that app.js is failing to load. In the local version, app.js doesn't
give a 404, but instead has the content of index.html because of the
way the webpack dev server works.

After this change, the exception for app.js is no longer there.

**- A picture of a cute animal (not mandatory but encouraged)**
![furious-george](https://user-images.githubusercontent.com/983/74950068-95ce9900-53cc-11ea-875f-20143f738c54.jpg)
