### PR TITLE
edited where certain links will take you

### DIFF
--- a/site/content/data-processing-agreement.md
+++ b/site/content/data-processing-agreement.md
@@ -19,7 +19,7 @@ Any capitalised term not defined in this DPA shall have the meaning given to it 
 
 “Processor”	means Kindly Ops LLC;
 
-“Security Documentation”	means the security documents located at https://enlist.io/security as amended from time to time, or as otherwise made available by the Processor to the Controller;
+“Security Documentation”	means the security documents located at [https://enlist.io/security](/security) as amended from time to time, or as otherwise made available by the Processor to the Controller;
 
 “Standard Contractual Clauses”	means the EU model clauses for Personal Data transfer from controllers to processors c2010-593 - Decision 2010/87EU;
 
@@ -78,7 +78,7 @@ All Sub-processors who process Personal Data in the provision of the Services to
 
 Where Sub-processors are located outside of the EEA, the Processor confirms that such Sub-processors: (i) are located in a third country or territory recognised by the EU Commission to have an adequate level of protection; or (ii) have entered into Standard Contractual Clauses with the Processor; or (iii) have other legally recognised appropriate safeguards in place, such as the EU-US Privacy Shield or Binding Corporate Rules.
 
-The Processor shall make available to the Controller the current list of Sub-processors (at https://enlist.io/subprocessors) which shall include the identities of Sub-processors and their country of location. During the term of this DPA, the Processor shall provide the Controller with at least 14 days prior notification, via email (or in-application notice), of any changes to the list of Sub-processor(s) who may process Personal Data before authorising any new or replacement Sub-processor(s) to process Personal Data in connection with the provision of the Services.
+The Processor shall make available to the Controller the current list of Sub-processors (at [https://enlist.io/subprocessors](/subprocessors)) which shall include the identities of Sub-processors and their country of location. During the term of this DPA, the Processor shall provide the Controller with at least 14 days prior notification, via email (or in-application notice), of any changes to the list of Sub-processor(s) who may process Personal Data before authorising any new or replacement Sub-processor(s) to process Personal Data in connection with the provision of the Services.
 
 If the Controller objects to a new or replacement Sub-processor the Controller may terminate the Terms of Use with respect to those Services which cannot be provided by the Processor without the use of the new or replacement Sub-processor. The Processor will refund the Controller any prepaid fees covering the remainder of the Term of the Terms of Use following the effective date of termination with respect to such terminated Services.
 

--- a/site/content/resources/guides/how-to-choose-an-applicant-tracking-system.md
+++ b/site/content/resources/guides/how-to-choose-an-applicant-tracking-system.md
@@ -103,7 +103,7 @@ Migrating your existing data can be tricky. It depends largely on what you want 
  #### Conclusion
 Choosing a new applicant tracking system—or moving to a different one—can be daunting. There's a lot to think of. It's an important choice for any growing business, so it's just as important to take your time and evaluate a few different systems and see what each one of them has to offer.
 
-We hope this guide helped! At enlist, we can help you make the process seamless, whether you're trying an applicant tracking system for the first time or moving from some software. Interested in trying us out? [Sign up yourself](https://hire.enlist.io/signup), or if you have any questions, [let us know](/demo).
+We hope this guide helped! At enlist, we can help you make the process seamless, whether you're trying an applicant tracking system for the first time or moving from some software. Interested in trying us out? [Schedule a demo](/demo) and let us help determine exactly how we can help you.
 
 __
 

--- a/site/content/resources/guides/how-to-set-up-an-employee-referral-program.md
+++ b/site/content/resources/guides/how-to-set-up-an-employee-referral-program.md
@@ -36,7 +36,7 @@ Now that you have the details, it's time to make it easy for your team to (a) kn
 A good job description is always helpful, in this case not only for candidates but also your own team. When your employees understand the role well, they are able to make better recommendations. So, the first thing to take care of is a [good, detailed job description](/resources/posting-jobs/write-good-job-descriptions) that lists all the qualities you want (and all that you don't).
 
 #### Make it easy for referrers to track status
-You also need a way for your employees to actually refer candidates, track their progress, and for you to track employee referrals all in one place. A good [referral tracking system](https://enlist.io/) can be really helpful, but even if you don't have one, a simple spreadsheet should be sufficient for a start.
+You also need a way for your employees to actually refer candidates, track their progress, and for you to track employee referrals all in one place. A good [referral tracking system](/) can be really helpful, but even if you don't have one, a simple spreadsheet should be sufficient for a start.
 
 It's important to keep employees who refer other candidates in the loop. Let them know the status of their referrals, or better yet, use something that can allow them to track status on their own. Even if you don't end up hiring a referral, it's important to thank the people who are sending these referrals your way. Even better if you can send them a small gift for referring other people.
 
@@ -49,7 +49,7 @@ Beyond that, you should also consider offering a monetary reward to your best re
 
 Want to get creative? Look for other companies’ referral programs to get some ideas. For example, [DigitalOcean pays a $3500 referral bonus and a $1500 donation to a charity of the referrer’s choice.](https://brightfunds.blog/2017/09/06/digitalocean-case-study/) Google’s employee referral strategy is [even more interesting](https://www.inc.com/robbie-abed/google-spent-3-years-finding-out-how-to-get-more-employees-to-refer-new-candidates-heres-what-they-learned.html) and has a lot of lessons applicable to even smaller businesses.
 
-Once you have your referral program running, it's important to review it and make improvements on a regular basis. Take a look at how many referrals you are generating and how many are getting hired. Find out what your team feels about it. An easy way would to get your team’s feedback would be to quickly survey your team. There are tools that can help with this, but your [applicant tracking system](https://enlist.io/) can also do the job for you.
+Once you have your referral program running, it's important to review it and make improvements on a regular basis. Take a look at how many referrals you are generating and how many are getting hired. Find out what your team feels about it. An easy way would to get your team’s feedback would be to quickly survey your team. There are tools that can help with this, but your [applicant tracking system](/) can also do the job for you.
 
 Employee referral programs may sound daunting but they aren't. In fact, a good referral program can give you a great return for the time (and money!) you invest, perhaps better than any other channel.
 

--- a/site/content/resources/job-description-templates/human-resources/recruitment-specialist-job-description-template.md
+++ b/site/content/resources/job-description-templates/human-resources/recruitment-specialist-job-description-template.md
@@ -23,7 +23,7 @@ As a recruitment specialist you will be responsible for sourcing candidates, ass
  * Bachelor's degree in business or a related field
  * Previous experience in the recruitment industry or a HR position
  * Working knowledge of MS Office applications like Outlook, Word and Excel
- * Familiarity with [Application Tracking Systems](https://enlist.io/) (ATS)
+ * Familiarity with [Application Tracking Systems](/) (ATS)
  * Excellent written and verbal communication skills
  * Willingness to travel and meet with candidates and clients
  * Extensive knowledge of various industries and related jobs

--- a/site/content/resources/misc/do-small-businesses-need-an-applicant-tracking-system.md
+++ b/site/content/resources/misc/do-small-businesses-need-an-applicant-tracking-system.md
@@ -43,5 +43,5 @@ Using an applicant tracking system from early in your company’s history can al
 
 As you can see, there are several reasons why a small business can benefit from an applicant tracking system just as well as a medium sized or a large business. For most small businesses, though, there are two major concerns: affordability and the ease of use. You don’t want to get locked in with a contract that costs an arm and a leg and you definitely don’t want a cumbersome, hard to use product which nobody on your team likes.
 
-Fortunately, you have great options in today’s world. Many applicant tracking systems (like [enlist](https://enlist.io/)) are priced per job which means that they scale as you add jobs. They are also built for small businesses which means they are easy and quick to get started with, and easy to use.
+Fortunately, you have great options in today’s world. Many applicant tracking systems (like [enlist](/)) are priced per job which means that they scale as you add jobs. They are also built for small businesses which means they are easy and quick to get started with, and easy to use.
 

--- a/site/content/resources/posting-jobs/creating-a-great-candidate-experience.md
+++ b/site/content/resources/posting-jobs/creating-a-great-candidate-experience.md
@@ -37,7 +37,7 @@ It's not possible to give feedback to everyone who applies, especially if you ha
 Nobody likes rejection. By telling them what they could have done better, you ensure that they get some value out of the time they spent interviewing with your company.
 
 #### Ask for feedback
-No process is perfect. Despite your best intentions, you may end up missing something. By asking for feedback, you give yourself much better visibility into the problems your candidates are facing. Sending a quick survey with your [applicant tracking system](https://enlist.io/) should be straightforward.
+No process is perfect. Despite your best intentions, you may end up missing something. By asking for feedback, you give yourself much better visibility into the problems your candidates are facing. Sending a quick survey with your [applicant tracking system](/) should be straightforward.
 
 Over time, you can iteratively improve the experience to a point where it's near-perfect.
 

--- a/site/content/resources/posting-jobs/write-good-job-descriptions.md
+++ b/site/content/resources/posting-jobs/write-good-job-descriptions.md
@@ -47,7 +47,7 @@ Apart from the salary, it's a great idea to list all the benefits that you offer
 Just like a candidate’s cover letter is (often) your first impression of them, your job descriptions is their first impressions of you. So, it’s important to proofread your job description before posting to make sure you haven’t left out critical details or made other small mistakes.
 
 ---
-If you're hiring for several positions, a recruitment software like [enlist](https://enlist.io/) can be helpful. [Sign up for a free trial](https://hire.enlist.io/signup), or get in touch with us for a [demo](/demo).
+If you're hiring for several positions, a recruitment software like [enlist](/) can be helpful. [Contact us for a demo.](/demo)
 
 __
 

--- a/site/content/resources/scaling/scaling-recruitment-how-to-hire-when-youre-growing-fast.md
+++ b/site/content/resources/scaling/scaling-recruitment-how-to-hire-when-youre-growing-fast.md
@@ -24,7 +24,7 @@ Every job will have a different process but you must make sure that anyone apply
 #### Automate
 Every hiring process has a lot of grunt work that could easily be automated. Think about the thank you e-mails you send to candidates, the interview schedule requests, the review requests to your interviewers... all those are steps that are better automated.
 
-More advanced [hiring software](https://enlist.io/) will allow to you create workflows that can automate parts of your hiring. Adopting such a software when you're hiring at scale is a good idea.
+More advanced [hiring software](/) will allow to you create workflows that can automate parts of your hiring. Adopting such a software when you're hiring at scale is a good idea.
 
 It's important, however, to not take automation to its extremes. It's generally a bad idea to reject applications based on certain triggers. Unless you absolutely cannot work without a certain credential or a certain requirement, it is better to screen people manually even if it takes a bit more time.
 

--- a/site/content/resources/screening/candidate-screening.md
+++ b/site/content/resources/screening/candidate-screening.md
@@ -28,7 +28,7 @@ What should you look for when screening candidates by their resumes? It's a good
  * Are there any references? Some resumes may have these, but it's more common to get references at a later stage when you actually ask for them.
  * Is there anything else that stands out? There are candidates who may have an unusual career path but they may be standout performers in the right environment. If there are skills on the resume that stand out otherwise, that may be worth looking at.
 
-In the recent years, [applicant tracking systems](https://enlist.io/) have evolved to offer automated resume screening, a technique in which these systems look for certain keywords in a candidate's resume and automatically reject them if they don't find those keywords.
+In the recent years, [applicant tracking systems](/) have evolved to offer automated resume screening, a technique in which these systems look for certain keywords in a candidate's resume and automatically reject them if they don't find those keywords.
 
 In theory, it sounds great: it saves you a lot of time and you don't get any irrelevant applications. In practice, it doesn't work so well. As a technique, it isn't perfect. There are a lot of false negatives, a lot of false positives, and you end up losing a lot of good, well-suited candidates too.
 

--- a/site/content/resources/sourcing/outbound-hiring.md
+++ b/site/content/resources/sourcing/outbound-hiring.md
@@ -15,7 +15,7 @@ There are several ways to go about this. One of the best that we have found is t
 
 Another good way is to look at social media sites, like Twitter and LinkedIn. You could send candidates that are interested an InMail. There are other great options when you're looking for designers or developers. Github is great for finding people who have worked with a certain technology and Dribbble is a great resource for finding designers.
 
-Beyond these two, you could always look for sourcing sites (such as [Sourcing.io](https://sourcing.io/)). There are many options out there, even if you're looking for roles that are traditionally difficult to fill. Your [applicant tracking system](https://enlist.io/) may have integrations that allow you to import candidates with one click.
+Beyond these two, you could always look for sourcing sites (such as [Sourcing.io](https://sourcing.io/)). There are many options out there, even if you're looking for roles that are traditionally difficult to fill. Your [applicant tracking system](/) may have integrations that allow you to import candidates with one click.
 
 Once you have put together a list of a few people you think might be a good fit, what next?
 

--- a/site/content/resources/sourcing/recruitment-emails.md
+++ b/site/content/resources/sourcing/recruitment-emails.md
@@ -57,7 +57,7 @@ Once you've sent an email, it's important to follow up if required after a few d
 Try to keep follow up emails to two at most. If someone hasn't responded after a couple of followups, it's safe to assume that they probably aren't interested. That obviously doesn't mean that the door is shut forever: you might get a response some time later!
 
 #### Use software to complement your work
-Doing all of this by yourself can be tedious. A [recruitment software](https://enlist.io/) can help remove some of the more repetitive tasks and it can complement your work too. It can make it easier for you to review someone's profile, to follow up with them at the right time, and even write better emails.
+Doing all of this by yourself can be tedious. A [recruitment software](/) can help remove some of the more repetitive tasks and it can complement your work too. It can make it easier for you to review someone's profile, to follow up with them at the right time, and even write better emails.
 
 Like most other things, writing a great recruitment email will take time, practice, and a lot of experimentation. You aren't going to find your voice in the first go, but a few tries and you should be set.
 

--- a/site/layouts/jobs/single.html
+++ b/site/layouts/jobs/single.html
@@ -4,7 +4,7 @@
     <h1 class="f3 lh-title b mt3 mb3">{{.Title}}</h1>
     <div class="mw6 bg-yellow">
       <p class="pa2 lh-copy measure">
-        Get started with this {{.Title}}, customize it, and post it to the jobs boards you want. Hiring for more jobs? <a style= "font-weight:bold" href="https://enlist.io">Try out enlist.</a>
+        Get started with this {{.Title}}, customize it, and post it to the jobs boards you want. Hiring for more jobs? <a style= "font-weight:bold" href="/">Try out enlist.</a>
       </p>
     </div>
     <div class="cms mw6 pa2 ba b--dashed mb3 bw1">

--- a/site/layouts/partials/short-text.html
+++ b/site/layouts/partials/short-text.html
@@ -9,7 +9,7 @@
   </div>
 
   <div class="tc">
-    <a href="https://go.enlist.io/quiz32473759" class="btn raise">Start a free trial</a>
+    <a href="/demo" class="btn raise">Start a free trial</a>
   </div>
 
 

--- a/site/layouts/partials/table-column.html
+++ b/site/layouts/partials/table-column.html
@@ -10,7 +10,7 @@
 
 		<!-- Button -->
 		<div class="tc">
-			<a href="https://go.enlist.io/quiz32473759?utm_medium=pricing_trial_basic&utm_source=website"
+			<a href="/demo"
 			class="btn raise">Start a free trial </a>
 		</div>
 	</div>


### PR DESCRIPTION
**- Summary**

I edited all links anywhere within the code that were pointing to  (https://enlist.io/)  and instead pointed them to ( / )
Other links were also changed to point to their corresponding page within the hugo site. Example: a link that pointed to (https://enlist.io/subprocessors) now just points to (/subprocessors)
Any demo or sign up links now point to (/demo) rather than an external sign up page or the go.enlist page.

I think thats it. 