### PR TITLE
Add codeowners to facilitate review auto-assignment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+*    @knmurphy
+


### PR DESCRIPTION
this makes it so github auto-assignment of reviews works. assignment of reviews makes it so the PR reminder integration in slack works. the PR reminder integration in slack helps us not forget pending code.